### PR TITLE
Cron Job for rotation - New container & bugfix cron bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ script:
       if [[ "$look_exit" = "0" ]]; then echo "found semaphore"; break; fi; 
     done;
 
+  # Run the rotation cron, and make sure it exits without any output.
+  - docker exec -it homer-cron /opt/homer_rotate | grep -iP "^$"
   # Now you can run HEPGEN.js
   - docker exec -it hepgen node hepgen.js
   # Check that there's something in the database, we select the count of calls from HEPGEN.js, and verify there's 3 calls counted

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,10 @@ script:
     done;
 
   # Run the rotation cron, and make sure it exits without any output.
-  - docker exec -it homer-cron /opt/homer_rotate | grep -iP "^$"
+  - >
+    cron_result=$(docker exec -it homer-cron bash -c "/opt/homer_rotate") && echo $cron_result | grep -i "^$"
+  
+
   # Now you can run HEPGEN.js
   - docker exec -it hepgen node hepgen.js
   # Check that there's something in the database, we select the count of calls from HEPGEN.js, and verify there's 3 calls counted

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,6 @@ script:
       if [[ "$look_exit" = "0" ]]; then echo "found semaphore"; break; fi; 
     done;
 
-  # Run the rotation cron, and make sure it exits without any output.
-  - >
-    cron_result=$(docker exec -it homer-cron bash -c "/opt/homer_rotate") && echo $cron_result | grep -i "^$"
-  
-
   # Now you can run HEPGEN.js
   - docker exec -it hepgen node hepgen.js
   # Check that there's something in the database, we select the count of calls from HEPGEN.js, and verify there's 3 calls counted
@@ -59,3 +54,8 @@ script:
   # Check that there's a web connection on local host, returning a 200 OK
   - > 
     curl -s -o /dev/null -w "%{http_code}" localhost | grep -iP "^200$"
+
+  # Run the rotation cron, and make sure it exits without any output.
+  - docker exec -it homer-cron bash -c "/opt/homer_rotate"
+  - >
+    cron_result=$(docker exec -it homer-cron bash -c "/opt/homer_rotate") && echo $cron_result | grep -i "^$"

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,6 @@ script:
     curl -s -o /dev/null -w "%{http_code}" localhost | grep -iP "^200$"
 
   # Run the rotation cron, and make sure it exits without any output.
-  - docker exec -it homer-cron bash -c "/opt/homer_rotate"
-  - >
-    cron_result=$(docker exec -it homer-cron bash -c "/opt/homer_rotate") && echo $cron_result | grep -i "^$"
+  # - docker exec -it homer-cron bash -c "/opt/homer_rotate"
+  # - >
+  #   cron_result=$(docker exec -it homer-cron bash -c "/opt/homer_rotate") && echo $cron_result | grep -i "^$"

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -1,0 +1,16 @@
+FROM qxip/homer-webapp
+MAINTAINER L. Mangani <lorenzo.mangani@gmail.com>
+ENV BUILD_DATE 2016-03-23
+
+# Install the cron service
+RUN touch /var/log/cron.log
+RUN apt-get update -qq && apt-get install cron mysql-client -y && rm -rf /var/lib/apt/lists/*
+
+# Add our crontab file
+RUN echo "30 3 * * * /opt/homer_rotate >> /var/log/cron.log 2>&1" > /crons.conf
+RUN crontab /crons.conf
+
+COPY run.sh /run.sh
+RUN chmod a+rx /run.sh
+
+ENTRYPOINT ["/run.sh"]

--- a/cron/run.sh
+++ b/cron/run.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# ----------------------------------------------------
+# HOMER 5 Docker (http://sipcapture.org)
+# ----------------------------------------------------
+# -- Run script for Homer's cron jobs
+# ----------------------------------------------------
+# Reads from environment variables to set:
+# DB_PASS             MySQL password (homer_password)
+# DB_USER             MySQL user (homer_user)
+# DB_HOST             MySQL host (127.0.0.1 [docker0 bridge])
+# ----------------------------------------------------
+
+while [[ ! -f "/homer-semaphore/.bootstrapped" ]]; do
+  echo "Homer cron container, waiting for MySQL"
+  sleep 2;
+done
+
+
+# Reconfigure rotation
+
+export PATH_ROTATION_SCRIPT=/opt/homer_rotate
+chmod 775 $PATH_ROTATION_SCRIPT
+chmod +x $PATH_ROTATION_SCRIPT
+perl -p -i -e "s/homer_user/$DB_USER/" $PATH_ROTATION_SCRIPT
+perl -p -i -e "s/homer_password/$DB_PASS/" $PATH_ROTATION_SCRIPT
+perl -p -i -e "s/mysql \-u/mysql -h$DB_HOST -u/" $PATH_ROTATION_SCRIPT
+
+PERL_SCRIPTS=(/opt/homer_mysql_new_table.pl /opt/homer_mysql_partrotate_unixtimestamp.pl)
+for perl_script in ${PERL_SCRIPTS[@]}
+do
+  perl -p -i -e "s/homer_user/$DB_USER/" $perl_script
+  perl -p -i -e "s/homer_password/$DB_PASS/" $perl_script
+  perl -p -i -e "s/mysql_host = \"localhost\"/mysql_host = \"$DB_HOST\"/" $perl_script
+done
+
+# Init rotation
+# /opt/homer_rotate > /dev/null 2>&1
+/opt/homer_rotate
+
+# Start the cron service in the foreground, which will run rotation
+cron -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,19 @@ services:
       - "mysql:mysql"
     env_file:
       - ./homer.env
+  # --------------------------------------------- cron container
+  cron:
+    container_name: homer-cron
+    build: ./cron/.
+    image: qxip/homer-cron
+    depends_on:
+      - mysql
+    volumes:
+      - homer-data-semaphore:/homer-semaphore/
+    links:
+      - "mysql:mysql"
+    env_file:
+      - ./homer.env
   # --------------------------------------------- Kamailio container
   kamailio:
     container_name: homer-kamailio

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -30,14 +30,6 @@ COPY configuration.php /var/www/html/api/configuration.php
 COPY preferences.php /var/www/html/api/preferences.php
 COPY vhost.conf /etc/apache2/sites-enabled/000-default.conf
 
-# Install the cron service
-RUN touch /var/log/cron.log
-RUN apt-get update -qq && apt-get install cron -y && rm -rf /var/lib/apt/lists/*
-
-# Add our crontab file
-RUN echo "30 3 * * * /opt/homer_rotate >> /var/log/cron.log 2>&1" > /crons.conf
-RUN crontab /crons.conf
-
 COPY run.sh /run.sh
 RUN chmod a+rx /run.sh
 

--- a/webapp/run.sh
+++ b/webapp/run.sh
@@ -34,25 +34,6 @@ mkdir /var/www/html/api/tmp
 chmod -R 0777 /var/www/html/api/tmp/
 chmod -R 0775 /var/www/html/store/dashboard*
 
-# Reconfigure rotation
-
-export PATH_ROTATION_SCRIPT=/opt/homer_rotate
-chmod 775 $PATH_ROTATION_SCRIPT
-chmod +x $PATH_ROTATION_SCRIPT
-perl -p -i -e "s/homer_user/$DB_USER/" $PATH_ROTATION_SCRIPT
-perl -p -i -e "s/homer_password/$DB_PASS/" $PATH_ROTATION_SCRIPT
-
-export PATH_NEW_TABLE_SCRIPT=/opt/homer_mysql_new_table.pl
-perl -p -i -e "s/homer_user/$DB_USER/" $PATH_NEW_TABLE_SCRIPT
-perl -p -i -e "s/homer_password/$DB_PASS/" $PATH_NEW_TABLE_SCRIPT
-perl -p -i -e "s/mysql_host = \"localhost\"/mysql_host = \"$DB_HOST\"/" $PATH_NEW_TABLE_SCRIPT
-
-# Init rotation
-/opt/homer_rotate > /dev/null 2>&1
-
-# Start the cron service in the background for rotation
-cron -f &
-
 #enable apache mod_php and mod_rewrite
 a2enmod php5
 a2enmod rewrite 


### PR DESCRIPTION
Adds a new container (and docker-compose definition for it) to run the cron process, and also addresses the bug as listed in #2 

The deal with #2 is that the `/opt/homer_rotate` script didn't have intelligence about what host to use for a database, and tried to use localhost everywhere.

There's still a to-do -- this one needs a regression test for the cron running. I took a stab but wasn't having luck, but, would rather submit the PR for the bugfix rather than delay it for this, it's a net improvement.
