### PR TITLE
MYSQL must have UTC timezone.

### DIFF
--- a/bootstrap-data/bootstrap.sh
+++ b/bootstrap-data/bootstrap.sh
@@ -68,6 +68,9 @@ if [[ ! "$databases" =~ "homer_data" ]]; then
   # echo "Creating local DB Node..."
   mysql --host "$DB_HOST" -u "$DB_USER" homer_configuration -e "REPLACE INTO node VALUES(1,'mysql','homer_data','3306','"$DB_USER"','"$DB_PASS"','sip_capture','node1', 1);"
 
+  # set mysql timezone to UTC.
+  mysql --host "$DB_HOST" -u "$DB_USER" -e "SET @@global.time_zone='+00:00'"
+
   echo "Homer initial data load complete" > $DATADIR/.homer_initialized
 else
   echo "Detected Homer databases are already installed."


### PR DESCRIPTION
By default, when running docker-compose up, the container for
MYSQL will have the timezone of the host (in my tests CEST).
That means that any connection against MYSQL will be considered by
the server as CEST connection.
As siptrace is using gettimeofday to fill the timestamp header in
HEPv2+, the timestamp received by homer-kamailio is in UTC.
When sipcapture inserts the packet into MYSQL, as the connection is
considered by the database server as CEST and the data type used is
timestamp, MYSQL will try to convert the inserted timestamp to UTC.
That means the inserted timestamp will be 2 hours behind the real
hour in my example.
