### PR TITLE
Add config in kamailio for destination stats

### DIFF
--- a/kamailio/kamailio.cfg
+++ b/kamailio/kamailio.cfg
@@ -20,7 +20,7 @@
 
 ####### Global Parameters #########
 
-debug=1
+debug=2
 log_stderror=no
 
 memdbg=5
@@ -28,6 +28,7 @@ memlog=5
 
 ##!define WITH_HOMER_GEO
 ##!define WITH_HOMER_CUSTOM_STATS #enable it for HTTP custom stats
+#!define WITH_HOMER_DEST_STATS
 
 log_facility=LOG_LOCAL1
 
@@ -108,6 +109,10 @@ stats.min = 5 desc "My stats TIME min"
 # - processing of any incoming SIP request starts with this route
 route {
 
+#!ifdef WITH_HOMER_DEST_STATS
+    route(PARSE_DEST_STATS);
+#!endif
+
 	if($sht(a=>method::total) == $null) $sht(a=>method::total) = 0;
 	$sht(a=>method::total) = $sht(a=>method::total) + 1;
 	if($sht(a=>packet::count) == $null) $sht(a=>packet::count) = 0;
@@ -116,7 +121,6 @@ route {
 	 #Packets
         $sht(a=>packet::count) = $sht(a=>packet::count) + 1;
         $sht(a=>packet::size) = $sht(a=>packet::size) + $ml;
-
 
 	if($sht(b=>$rm::$cs::$ci) != $null) {
 		#$var(a) = "sip_capture_call" + "_%Y%m%d";
@@ -128,7 +132,8 @@ route {
 	$sht(b=>$rm::$cs::$ci) = 1;	
 	if($sht(a=>method::all) == $null) $sht(a=>method::all) = 0;
 	$sht(a=>method::all) = $sht(a=>method::all) + 1;
-	
+
+
 	if (is_method("INVITE|REGISTER")) {
 
 		if($ua =~ "(friendly-scanner|sipvicious|sipcli)") {
@@ -274,8 +279,11 @@ route {
 }
 
 onreply_route {
+#!ifdef WITH_HOMER_DEST_STATS
+        route(PARSE_DEST_STATS);
+#!endif
 
-	if($sht(a=>method::total) == $null) $sht(a=>method::total) = 0;
+    if($sht(a=>method::total) == $null) $sht(a=>method::total) = 0;
 	$sht(a=>method::total) = $sht(a=>method::total) + 1;
 
 	if($sht(b=>$rs::$cs::$rm::$ci) != $null) {
@@ -411,6 +419,54 @@ onreply_route {
 	#Store
 	route(STORE);
 	drop;
+}
+
+route[PARSE_DEST_STATS] {
+    xlog("L_INFO", "Let's see if we enter P-Dest-Stats\n");
+    if($(hdr(P-Dest-Stats)) != $null) {
+        xlog("L_INFO", "P-Dest-Stats is present rm:$rm, rs:$rs\n");
+        $var(country) = "UN";
+        $var(prefix) = "000";
+        $var(duration) = "0";
+        $var(lat) = "0";
+        $var(lon) = "0";
+
+        if($rs == $null) {
+            $var(method) = $rm;
+            $var(reason) = "";
+        } else {
+            $var(method) = $rs;
+            $var(reason) = $rr;
+        }
+
+        if($(hdr(P-Dest-Stats){param.value,CC}) != ""){
+            $var(country) = $(hdr(P-Dest-Stats){param.value,CC});
+            xlog("L_INFO", "SETTING country: $var(country)\n");
+        }
+
+        if($(hdr(P-Dest-Stats){param.value,PR}) != ""){
+            $var(prefix) = $(hdr(P-Dest-Stats){param.value,PR});
+            xlog("L_INFO", "SETTING prefix: $var(prefix)\n");
+        }
+
+        if($(hdr(P-Dest-Stats){param.value,Dur}) != ""){
+            $var(duration) = $(hdr(P-Dest-Stats){param.value,Dur});
+            xlog("L_INFO", "SETTING duration: $var(duration)\n");
+        }
+
+        if($(hdr(P-Dest-Stats){param.value,Lat}) != ""){
+            $var(lat) = $(hdr(P-Dest-Stats){param.value,Lat});
+            xlog("L_INFO", "SETTING lat: $var(lat)\n");
+        }
+
+        if($(hdr(P-Dest-Stats){param.value,Lon}) != ""){
+            $var(lon) = $(hdr(P-Dest-Stats){param.value,Lon});
+            xlog("L_INFO", "SETTING lon: $var(lon)\n");
+        }
+
+        sql_query("cb", "INSERT INTO stats_dest_mem (method, reply_reason, prefix, country, lat, lon, duration, total) VALUES('$var(method)', '$var(reason)', '$var(prefix)', '$var(country)', '$var(lat)', '$var(lon)', $var(duration), 1) ON DUPLICATE KEY UPDATE total=total+1, duration=duration+VALUES(duration)");
+        xlog("L_INFO", "EXECUTING QUERY: INSERT INTO stats_dest_mem (method, reply_reason, prefix, country, lat, lon, duration, total) VALUES('$var(method)', '$var(reason)', '$var(prefix)', '$var(country)', '$var(lat)', '$var(lon)', $var(duration), 1) ON DUPLICATE KEY UPDATE total=total+1, duration=duration+VALUES(duration)\n");
+    }
 }
 
 route[KILL_VICIOUS] {
@@ -553,7 +609,12 @@ route[CHECK_STATS] {
     sql_query("cb", "INSERT INTO stats_geo (from_date, to_date, method, country, lat, lon, total) SELECT $var(f_date) as from_date, $var(t_date) as to_date, method, country, lat, lon, total FROM stats_geo_mem;");
     sql_query("cb", "TRUNCATE TABLE stats_geo_mem");
 #!endif
-    
+
+#!ifdef WITH_HOMER_DEST_STATS
+    sql_query("cb", "INSERT INTO stats_dest_reply (from_date, to_date, prefix, method, reply_reason, country, lat, lon, total) SELECT $var(f_date) as from_date, $var(t_date) as to_date, prefix, method, reply_reason, country, lat, lon, total FROM stats_dest_mem;");
+    sql_query("cb", "TRUNCATE TABLE stats_dest_mem");
+#!endif
+
     #INSERT SQL STATS
     #Packet HEP stats
     if($sht(a=>packet::count) != $null && $sht(a=>packet::count) > 0) {


### PR DESCRIPTION
This is part of a series of Pull Request affecting homer-api, homer-ui and homer-docker to provide homer the ability to generate statistics based on the destination (mainly for VoIP OUT/ interconnection with PSTN)

This P/R provides basic stats about the number of different SIP replies for each prefix and contry.
As each implementation is different, the way to provide the data to homer is to inject a header into the messages you want the statistics.
