### PR TITLE
[kamailio] changes config to remove WITH_HOMER_DEST_STATS in Kamailio…

### DIFF
--- a/kamailio/kamailio.cfg
+++ b/kamailio/kamailio.cfg
@@ -28,7 +28,7 @@ memlog=5
 
 ##!define WITH_HOMER_GEO
 ##!define WITH_HOMER_CUSTOM_STATS #enable it for HTTP custom stats
-#!define WITH_HOMER_DEST_STATS
+##!define WITH_HOMER_DEST_STATS
 
 log_facility=LOG_LOCAL1
 


### PR DESCRIPTION
Changes to the Kamailio config to prevent the errors for "'stats_dest_reply' and 'stats_dest_mem' do not exist" in #22 
