### PR TITLE
Allow non-default mysql port and usage of callid_aleg_header

### DIFF
--- a/homer.env
+++ b/homer.env
@@ -14,6 +14,9 @@ DB_PASS=homer_password
 USE_REMOTE_MYSQL=false
 DB_HOST=mysql
 
+# This allows to set up a port different than the default one
+DB_PORT=3306
+
 # Root password for mysql (if a local instance)
 MYSQL_ROOT_PASSWORD=secret
 

--- a/kamailio/kamailio.cfg
+++ b/kamailio/kamailio.cfg
@@ -11,11 +11,14 @@
 #!substdef "!HOMER_DB_USER!{{ DB_USER }}!g"
 #!substdef "!HOMER_DB_PASSWORD!{{ DB_PASS }}!g"
 #!substdef "!HOMER_DB_HOST!{{ DB_HOST }}!g"
+#!substdef "!HOMER_DB_PORT!{{ DB_PORT }}!g"
 #!substdef "!HOMER_LISTEN_PROTO!udp!g"
 #!substdef "!HOMER_LISTEN_IF!0.0.0.0!g"
 #!substdef "!HOMER_LISTEN_PORT!9060!g"
 
 # #!substdef "!HOMER_STATS_SERVER!tcp:HOMER_LISTEN_IF:8888!g"
+
+#!substdef "!CALLID_ALEG_HEADER!X-CallIDALeg!g"
 
 
 ####### Global Parameters #########
@@ -85,16 +88,17 @@ modparam("xhttp", "url_match", "^/api/v1/stat")
 modparam("rtimer", "timer", "name=ta;interval=60;mode=1;")
 modparam("rtimer", "exec", "timer=ta;route=TIMER_STATS")
 
-modparam("sqlops","sqlcon","cb=>mysql://HOMER_DB_USER:HOMER_DB_PASSWORD@HOMER_DB_HOST/homer_statistic")
+modparam("sqlops","sqlcon","cb=>mysql://HOMER_DB_USER:HOMER_DB_PASSWORD@HOMER_DB_HOST:HOMER_DB_PORT/homer_statistic")
 
 # ----- mi_fifo params -----
 
 ####### Routing Logic ########
-modparam("sipcapture", "db_url", "mysql://HOMER_DB_USER:HOMER_DB_PASSWORD@HOMER_DB_HOST/homer_data")
+modparam("sipcapture", "db_url", "mysql://HOMER_DB_USER:HOMER_DB_PASSWORD@HOMER_DB_HOST:HOMER_DB_PORT/homer_data")
 modparam("sipcapture", "capture_on", 1)
 modparam("sipcapture", "hep_capture_on", 1)
 modparam("sipcapture", "insert_retries", 5)
 modparam("sipcapture", "insert_retry_timeout", 10)
+modparam("sipcapture", "callid_aleg_header", "CALLID_ALEG_HEADER")
 #modparam("sipcapture", "capture_node", "homer01")
 
 #!ifdef WITH_HOMER_GEO

--- a/kamailio/run.sh
+++ b/kamailio/run.sh
@@ -8,6 +8,7 @@
 # DB_PASS             MySQL password (homer_password)
 # DB_USER             MySQL user (homer_user)
 # DB_HOST             MySQL host (127.0.0.1 [docker0 bridge])
+# DB_PORT             MySQL port (3306)
 # KAMAILIO_HEP_PORT   Kamailio HEP Socket port (9060)
 # ----------------------------------------------------
 
@@ -30,6 +31,7 @@ mv $PATH_KAMAILIO_CFG.tmp $PATH_KAMAILIO_CFG
 perl -p -i -e "s/\{\{ KAMAILIO_HEP_PORT \}\}/$KAMAILIO_HEP_PORT/" $PATH_KAMAILIO_CFG
 perl -p -i -e "s/\{\{ DB_PASS \}\}/$DB_PASS/" $PATH_KAMAILIO_CFG
 perl -p -i -e "s/\{\{ DB_HOST \}\}/$DB_HOST/" $PATH_KAMAILIO_CFG
+perl -p -i -e "s/\{\{ DB_PORT \}\}/$DB_PORT/" $PATH_KAMAILIO_CFG
 perl -p -i -e "s/\{\{ DB_USER \}\}/$DB_USER/" $PATH_KAMAILIO_CFG
 
 # Change kamailio datestamp for sql tables


### PR DESCRIPTION
kamailio.cfg: add DB_PORT
kamailio.cfg: add callid_aleg_header param and define

callid_aleg_header can have a `;` separated list of headers for which values Homer should correlate the call legs.