### PR TITLE
Associate method to response_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,24 @@ docker build --tag="sipcapture/homer-docker:local" ./everything/
 docker run -t -i sipcapture/homer-docker:local --name homer5
 docker exec -it homer5 bash
 ```
+
+### Appendix - Destination Stats
+
+By defining `WITH_HOMER_DEST_STATS` in kamailio.cfg it's possible to enable capturing data related to the dialled country, prefix, geolocation and duration.
+
+The data is transported inside a SIP header, `P-Dest-Stats`.
+
+Example:
+
+```
+P-Dest-Stats: CC=es;PR=+349;Dur=138;Lat=0;Lon=0
+```
+
+Kamailio will do two things:
+
+1. Populate the table `homer_statistic.stats_dest_mem` as soon as that header is found in a SIP message
+
+2. Every 5 minutes summarise the stats into `homer_statistic.stats_dest_reply` and empty `homer_statistic.stats_dest_mem`
+
+The data from `homer_statistic.stats_dest_reply` can be presented inside a `Sipcapture Stats` widget.
+

--- a/kamailio/kamailio.cfg
+++ b/kamailio/kamailio.cfg
@@ -437,9 +437,11 @@ route[PARSE_DEST_STATS] {
 
         if($rs == $null) {
             $var(method) = $rm;
+            $var(status_code) = "";
             $var(reason) = "";
         } else {
-            $var(method) = $rs;
+            $var(method) = $rm;
+            $var(status_code) = $rs;
             $var(reason) = $rr;
         }
 
@@ -468,8 +470,8 @@ route[PARSE_DEST_STATS] {
             xlog("L_INFO", "SETTING lon: $var(lon)\n");
         }
 
-        sql_query("cb", "INSERT INTO stats_dest_mem (method, reply_reason, prefix, country, lat, lon, duration, total) VALUES('$var(method)', '$var(reason)', '$var(prefix)', '$var(country)', '$var(lat)', '$var(lon)', $var(duration), 1) ON DUPLICATE KEY UPDATE total=total+1, duration=duration+VALUES(duration)");
-        xlog("L_INFO", "EXECUTING QUERY: INSERT INTO stats_dest_mem (method, reply_reason, prefix, country, lat, lon, duration, total) VALUES('$var(method)', '$var(reason)', '$var(prefix)', '$var(country)', '$var(lat)', '$var(lon)', $var(duration), 1) ON DUPLICATE KEY UPDATE total=total+1, duration=duration+VALUES(duration)\n");
+        sql_query("cb", "INSERT INTO stats_dest_mem (method, status_code, reason_phrase, prefix, country, lat, lon, duration, total) VALUES('$var(method)', '$var(status_code)', '$var(reason)', '$var(prefix)', '$var(country)', '$var(lat)', '$var(lon)', $var(duration), 1) ON DUPLICATE KEY UPDATE total=total+1, duration=duration+VALUES(duration)");
+        xlog("L_INFO", "EXECUTING QUERY: INSERT INTO stats_dest_mem (method, status_code, reason_phrase, prefix, country, lat, lon, duration, total) VALUES('$var(method)', '$var(status_code)', '$var(reason)', '$var(prefix)', '$var(country)', '$var(lat)', '$var(lon)', $var(duration), 1) ON DUPLICATE KEY UPDATE total=total+1, duration=duration+VALUES(duration)\n");
     }
 }
 
@@ -615,7 +617,7 @@ route[CHECK_STATS] {
 #!endif
 
 #!ifdef WITH_HOMER_DEST_STATS
-    sql_query("cb", "INSERT INTO stats_dest_reply (from_date, to_date, prefix, method, reply_reason, country, lat, lon, total) SELECT $var(f_date) as from_date, $var(t_date) as to_date, prefix, method, reply_reason, country, lat, lon, total FROM stats_dest_mem;");
+    sql_query("cb", "INSERT INTO stats_dest_reply (from_date, to_date, prefix, method, status_code, reason_phrase, country, lat, lon, total) SELECT $var(f_date) as from_date, $var(t_date) as to_date, prefix, method, status_code, reason_phrase, country, lat, lon, total FROM stats_dest_mem;");
     sql_query("cb", "TRUNCATE TABLE stats_dest_mem");
 #!endif
 

--- a/kamailio/kamailio.cfg
+++ b/kamailio/kamailio.cfg
@@ -426,9 +426,8 @@ onreply_route {
 }
 
 route[PARSE_DEST_STATS] {
-    xlog("L_INFO", "Let's see if we enter P-Dest-Stats\n");
     if($(hdr(P-Dest-Stats)) != $null) {
-        xlog("L_INFO", "P-Dest-Stats is present rm:$rm, rs:$rs\n");
+        xlog("L_DBG", "P-Dest-Stats is present rm:$rm, rs:$rs\n");
         $var(country) = "UN";
         $var(prefix) = "000";
         $var(duration) = "0";
@@ -447,31 +446,31 @@ route[PARSE_DEST_STATS] {
 
         if($(hdr(P-Dest-Stats){param.value,CC}) != ""){
             $var(country) = $(hdr(P-Dest-Stats){param.value,CC});
-            xlog("L_INFO", "SETTING country: $var(country)\n");
+            xlog("L_DBG", "SETTING country: $var(country)\n");
         }
 
         if($(hdr(P-Dest-Stats){param.value,PR}) != ""){
             $var(prefix) = $(hdr(P-Dest-Stats){param.value,PR});
-            xlog("L_INFO", "SETTING prefix: $var(prefix)\n");
+            xlog("L_DBG", "SETTING prefix: $var(prefix)\n");
         }
 
         if($(hdr(P-Dest-Stats){param.value,Dur}) != ""){
             $var(duration) = $(hdr(P-Dest-Stats){param.value,Dur});
-            xlog("L_INFO", "SETTING duration: $var(duration)\n");
+            xlog("L_DBG", "SETTING duration: $var(duration)\n");
         }
 
         if($(hdr(P-Dest-Stats){param.value,Lat}) != ""){
             $var(lat) = $(hdr(P-Dest-Stats){param.value,Lat});
-            xlog("L_INFO", "SETTING lat: $var(lat)\n");
+            xlog("L_DBG", "SETTING lat: $var(lat)\n");
         }
 
         if($(hdr(P-Dest-Stats){param.value,Lon}) != ""){
             $var(lon) = $(hdr(P-Dest-Stats){param.value,Lon});
-            xlog("L_INFO", "SETTING lon: $var(lon)\n");
+            xlog("L_DBG", "SETTING lon: $var(lon)\n");
         }
 
         sql_query("cb", "INSERT INTO stats_dest_mem (method, status_code, reason_phrase, prefix, country, lat, lon, duration, total) VALUES('$var(method)', '$var(status_code)', '$var(reason)', '$var(prefix)', '$var(country)', '$var(lat)', '$var(lon)', $var(duration), 1) ON DUPLICATE KEY UPDATE total=total+1, duration=duration+VALUES(duration)");
-        xlog("L_INFO", "EXECUTING QUERY: INSERT INTO stats_dest_mem (method, status_code, reason_phrase, prefix, country, lat, lon, duration, total) VALUES('$var(method)', '$var(status_code)', '$var(reason)', '$var(prefix)', '$var(country)', '$var(lat)', '$var(lon)', $var(duration), 1) ON DUPLICATE KEY UPDATE total=total+1, duration=duration+VALUES(duration)\n");
+        xlog("L_DBG", "EXECUTING QUERY: INSERT INTO stats_dest_mem (method, status_code, reason_phrase, prefix, country, lat, lon, duration, total) VALUES('$var(method)', '$var(status_code)', '$var(reason)', '$var(prefix)', '$var(country)', '$var(lat)', '$var(lon)', $var(duration), 1) ON DUPLICATE KEY UPDATE total=total+1, duration=duration+VALUES(duration)\n");
     }
 }
 


### PR DESCRIPTION
This is part of 3 PRs involving homer-docker (kamailio.cfg), homer-api (api/RestApi/Statistic.php) and homer-ui (js/widgets/datasource.js).

The objective is to distinguish, in Destination Stats, responses associated to different methods, e.g. a 200 to INVITE from a 200 to BYE.