### PR TITLE
Add persistence to dashboards with a data container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - /homer-api/
       - homer-data-semaphore:/homer-semaphore/
+      - homer-data-dashboard:/var/www/html/store/dashboard/
     links:
       - "mysql:mysql"
     env_file:
@@ -87,3 +88,4 @@ services:
 volumes:
   homer-data-semaphore:
   homer-data-mysql:
+  homer-data-dashboard:


### PR DESCRIPTION
In this way the dashboards will persist re-installations and can also be backed up and/or moved into another host.