### PR TITLE
Restart containers on server restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - "mysql:mysql"
     env_file:
       - ./homer.env
+    restart: always
   # --------------------------------------------- cron container
   cron:
     container_name: homer-cron
@@ -29,6 +30,7 @@ services:
       - "mysql:mysql"
     env_file:
       - ./homer.env
+    restart: always
   # --------------------------------------------- Kamailio container
   kamailio:
     container_name: homer-kamailio
@@ -48,7 +50,8 @@ services:
     #   >
     #   -c 'while true; do sleep 60; done;'
     env_file:
-      - ./homer.env      
+      - ./homer.env
+    restart: always
   # --------------------------------------------- Data bootstrapping container
   bootstrap:
     container_name: bootstrap-mysql
@@ -71,7 +74,8 @@ services:
     entrypoint:
       - /bootstrap.sh
     env_file:
-      - ./homer.env      
+      - ./homer.env
+    restart: always
   # --------------------------------------------- MySQL container.
   mysql:
     container_name: mysql
@@ -84,6 +88,7 @@ services:
       - /run.sh
     env_file:
       - ./homer.env
+    restart: always
 volumes:
   homer-data-semaphore:
   homer-data-mysql:


### PR DESCRIPTION
Previously, when a server was rebooted or docker was upgraded, the
docker containers created by docker compose were stopped. This commit
configures docker compose to always restart the docker containers
when docker is started enabling for use in a production environment.