### PR TITLE
bootstrap-mysql doesn't need to restart on boot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,6 @@ services:
       - /bootstrap.sh
     env_file:
       - ./homer.env
-    restart: always
   # --------------------------------------------- MySQL container.
   mysql:
     container_name: mysql


### PR DESCRIPTION
This bootstrap-mysql docker container only needs to be run once when
starting docker-compose. It is not intended to keep running forever, so
removing the restart policy.