### PR TITLE
Clear any pre-existing PID files

### DIFF
--- a/webapp/run.sh
+++ b/webapp/run.sh
@@ -36,7 +36,10 @@ chmod -R 0775 /var/www/html/store/dashboard*
 
 #enable apache mod_php and mod_rewrite
 a2enmod php5
-a2enmod rewrite 
+a2enmod rewrite
+
+# Apache gets grumpy about PID files pre-existing
+rm -f /var/run/apache2/apache2.pid
 
 # Start Apache
 apachectl -DFOREGROUND


### PR DESCRIPTION
Now that we have a restart policy, the webapp container doesn't recover
as it should from a restart. This commit removes any previous PID files
so that Apache can start correctly. In theory this shouldn't be an issue
with docker due to it's design.

Per: https://github.com/docker-library/php/issues/187