### PR TITLE
Startup fix: rotation.ini and run.sh

### DIFF
--- a/cron/rotation.ini
+++ b/cron/rotation.ini
@@ -9,8 +9,9 @@
 [MYSQL]
     user=homer_user
     password=homer_password
-    host=localhost
+    host=mysql
     port=3306
+    usesocket=0
     db_data = homer_data
     db_stats = homer_statistic
     # Extra param

--- a/cron/run.sh
+++ b/cron/run.sh
@@ -18,11 +18,11 @@ done
 
 # Reconfigure rotation
 
-export PATH_ROTATION_SCRIPT=/opt/new/homer_rotate
+export PATH_ROTATION_SCRIPT=/opt/homer_rotate
 chmod 775 $PATH_ROTATION_SCRIPT
 chmod +x $PATH_ROTATION_SCRIPT
 
-export PATH_ROTATION_CONFIG=/opt/new/rotation.ini
+export PATH_ROTATION_CONFIG=/opt/rotation.ini
 
 perl -p -i -e "s/homer_user/$DB_USER/" $PATH_ROTATION_CONFIG
 perl -p -i -e "s/homer_password/$DB_PASS/" $PATH_ROTATION_CONFIG


### PR DESCRIPTION
- Fixed rotation.ini to add "usesocket" and set "host" properly to "mysql"
- Fixed cron/run.sh to set the paths to rotation.ini and homer_rotate
properly.
Docker now starts properly.