### PR TITLE
Bumps homer-api & homer-ui versions to latest heads

### DIFF
--- a/bootstrap-data/bootstrap.sh
+++ b/bootstrap-data/bootstrap.sh
@@ -20,7 +20,7 @@
 # sed '/\[mysqld\]/a max_connections = 1024\' -i $PATH_MYSQL_CONFIG
 
 # MYSQL SETUP
-SQL_LOCATION=/homer-api/sql
+SQL_LOCATION=/homer-api/sql/mysql
 DATADIR=/var/lib/mysql
 
 # ------- First thing we'll do is wait until mysql is up....

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -7,10 +7,10 @@ RUN touch /var/log/cron.log
 RUN apt-get update -qq && apt-get install cron mysql-client -y && rm -rf /var/lib/apt/lists/*
 
 # Add our crontab file
-RUN echo "30 3 * * * /opt/new/homer_rotate >> /var/log/cron.log 2>&1" > /crons.conf
+RUN echo "30 3 * * * /opt/homer_rotate >> /var/log/cron.log 2>&1" > /crons.conf
 RUN crontab /crons.conf
 
-COPY rotation.ini /opt/new/rotation.ini
+COPY rotation.ini /opt/rotation.ini
 
 COPY run.sh /run.sh
 RUN chmod a+rx /run.sh

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -7,7 +7,7 @@ RUN touch /var/log/cron.log
 RUN apt-get update -qq && apt-get install cron mysql-client -y && rm -rf /var/lib/apt/lists/*
 
 # Add our crontab file
-RUN echo "30 3 * * * /opt/homer_rotate >> /var/log/cron.log 2>&1" > /crons.conf
+RUN echo "30 3 * * * /opt/homer_mysql_rotate.pl >> /var/log/cron.log 2>&1" > /crons.conf
 RUN crontab /crons.conf
 
 COPY rotation.ini /opt/rotation.ini

--- a/cron/rotation.ini
+++ b/cron/rotation.ini
@@ -7,42 +7,59 @@
 # The run.sh will change these dynamically for you base on environment variables
 
 [MYSQL]
-    user=homer_user
-    password=homer_password
-    host=mysql
-    port=3306
-    usesocket=0
+    user = homer_user
+    password = homer_password
+    host = localhost
+    port = 3306
+    usesocket = 0
+    socket = /var/run/mysqld/mysqld.sock
     db_data = homer_data
     db_stats = homer_statistic
     # Extra param
-    newtables = 2
+    newtables = 2 # Create new tables or partitions for next 2 days
     engine = InnoDB #MyISAM or InnoDB
     compress=ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
 
 [DATA_TABLE_ROTATION]
     #how long data keeps
-    sip_capture_call = 14 #days
-    sip_capture_registration = 14 # 14 days
-    sip_capture_rest = 14 # 14 days
-    rtcp_capture = 14 # days
-    logs_capture = 14 # days
-    report_capture = 14 # days
+    sip_capture_call = 10 #days
+    sip_capture_registration = 10 # 10 days
+    sip_capture_rest = 10 # 10 days
+    rtcp_capture_all = 10 # days
+    logs_capture = 10 # days
+    report_capture = 10 # days
+    webrtc_capture_all = 10 # days
+    isup_capture_all = 10
 
 [DATA_TABLE_STEP]
     # 0 - Day, 1 - Hour, 2 - 30 Minutes, 3 - 15 Minutes
     sip_capture_call = 0
     sip_capture_registration = 0
     sip_capture_rest = 0
-    rtcp_capture = 0
+    rtcp_capture_all = 0
     logs_capture = 0
     report_capture = 0
+    webrtc_capture_all = 0
+    isup_capture_all = 0
+
+[DROP_OLD_PARTITIONS]
+    # Remove partitions older than $seconds
+    # Ignored if zero
+    sip_capture_call = 0
+    sip_capture_registration = 0
+    sip_capture_rest = 0
+    rtcp_capture_all = 0
+    logs_capture = 0
+    report_capture = 0
+    isup_capture_all = 0
+    webrtc_capture_all = 0
 
 [STATS_TABLE_ROTATION]
-    stats_ip = 28 # days
-    stats_geo = 28 # days
-    alarm_data = 14 # days
-    stats_method = 14 #  days
-    stats_useragent = 28 # days
+    stats_ip = 20 # days
+    stats_geo = 20 # days
+    alarm_data = 10 # days
+    stats_method = 10 #  days
+    stats_useragent = 20 # days
 
 [STATS_TABLE_STEP]
     #0 - Day, 1 - Hour, 2 - 30 Minutes, 3 - 15 Minutes
@@ -54,3 +71,12 @@
 
 [SYSTEM]
     debug = 0
+    exec =  1
+
+[MSG_TABLE_SIZE]
+    #characters
+    sip_capture_call = 1500
+    isup_capture_all = 3000
+    webrtc_capture_all = 3000
+    rtcp_capture_all = 1500
+

--- a/cron/run.sh
+++ b/cron/run.sh
@@ -15,12 +15,17 @@ while [[ ! -f "/homer-semaphore/.bootstrapped" ]]; do
   sleep 2;
 done
 
+# Work around key size constraints (noted in issue @ https://github.com/sipcapture/homer-docker/issues/42)
+perl -p -i -e 's/\(`session_id`\)/(`session_id`(255))/' /opt/homer_mysql_rotate.pl 
+perl -p -i -e 's/\(`correlation_id`\)/(`correlation_id`(255))/' /opt/homer_mysql_rotate.pl
+
 
 # Reconfigure rotation
 
-export PATH_ROTATION_SCRIPT=/opt/homer_rotate
-chmod 775 $PATH_ROTATION_SCRIPT
-chmod +x $PATH_ROTATION_SCRIPT
+# --- I believe these are deprecated (@dougbtv, 3/30/17)
+# export PATH_ROTATION_SCRIPT=/opt/homer_rotate
+# chmod 775 $PATH_ROTATION_SCRIPT
+# chmod +x $PATH_ROTATION_SCRIPT
 
 export PATH_ROTATION_CONFIG=/opt/rotation.ini
 
@@ -28,16 +33,17 @@ perl -p -i -e "s/homer_user/$DB_USER/" $PATH_ROTATION_CONFIG
 perl -p -i -e "s/homer_password/$DB_PASS/" $PATH_ROTATION_CONFIG
 perl -p -i -e "s/localhost/$DB_HOST/" $PATH_ROTATION_CONFIG
 
-PERL_SCRIPTS=(/opt/homer_mysql_new_table.pl /opt/homer_mysql_partrotate_unixtimestamp.pl)
-for perl_script in ${PERL_SCRIPTS[@]}
-do
-  perl -p -i -e "s/homer_user/$DB_USER/" $perl_script
-  perl -p -i -e "s/homer_password/$DB_PASS/" $perl_script
-  perl -p -i -e "s/mysql_host = \"localhost\"/mysql_host = \"$DB_HOST\"/" $perl_script
-done
+# --- I believe these are deprecated (@dougbtv, 3/30/17)
+# PERL_SCRIPTS=(/opt/homer_mysql_new_table.pl /opt/homer_mysql_partrotate_unixtimestamp.pl)
+# for perl_script in ${PERL_SCRIPTS[@]}
+# do
+#   perl -p -i -e "s/homer_user/$DB_USER/" $perl_script
+#   perl -p -i -e "s/homer_password/$DB_PASS/" $perl_script
+#   perl -p -i -e "s/mysql_host = \"localhost\"/mysql_host = \"$DB_HOST\"/" $perl_script
+# done
 
 # Init rotation
-/opt/new/homer_rotate
+/opt/homer_mysql_rotate.pl
 
 # Ensure cron is allowed to run
 sed -i 's/^\(session\s\+required\s\+pam_loginuid\.so.*$\)/# \1/g' /etc/pam.d/cron

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       - ./homer.env
     restart: always
   # --------------------------------------------- Data bootstrapping container
+  # debug with:
+  # docker run -it --volumes-from homer-webapp --network homerdocker_default --link mysql:mysql mysql:5.6 /bin/bash
   bootstrap:
     container_name: bootstrap-mysql
     image: mysql:5.6

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -17,8 +17,8 @@ RUN a2enmod php5
 # HOMER 5
 ENV HOMER_VERSION_CACHE_BUSTER arbitrary_value_0x000000d00d
 
-RUN git clone https://github.com/sipcapture/homer-api.git /homer-api && cd /homer-api && git checkout 58fc5ab413583fc5b104a868413e8f7a7cb42ed9 && cd /
-RUN git clone https://github.com/sipcapture/homer-ui.git /homer-ui && cd /homer-ui && git checkout f5e1db6b31cb2761e2b7c9ac89d93672882b3062 && cd /
+RUN git clone https://github.com/sipcapture/homer-api.git /homer-api && cd /homer-api && git checkout 5cc1bac9187e2d6413cbf8f28b37747ce364b373 && cd /
+RUN git clone https://github.com/sipcapture/homer-ui.git /homer-ui && cd /homer-ui && git checkout 0e0805fe84a3937001c3e57d36ee4031b35c8083 && cd /
 
 WORKDIR /
 


### PR DESCRIPTION
Fixes #42 

Updates homer-api & homer-ui to latest heads where they're version pinned.

Has a few fixes in to support that version bump. Also works around a key length in the cron job to rotate tables.