### PR TITLE
'stats_data' was not included in rotation.ini, added it

### DIFF
--- a/cron/rotation.ini
+++ b/cron/rotation.ini
@@ -57,6 +57,7 @@
 [STATS_TABLE_ROTATION]
     stats_ip = 20 # days
     stats_geo = 20 # days
+    stats_data = 10 # days
     alarm_data = 10 # days
     stats_method = 10 #  days
     stats_useragent = 20 # days


### PR DESCRIPTION
In the rotation.ini file, "stats_data" was not included and thus not being rotate leading to filling up the hd.

I just added the table so that it is rotated.