### PR TITLE
Modified kamailio.cfg so KAMAILIO_HEP_PORT is used for listen, but no…

### DIFF
--- a/kamailio/kamailio.cfg
+++ b/kamailio/kamailio.cfg
@@ -14,7 +14,7 @@
 #!substdef "!HOMER_DB_PORT!{{ DB_PORT }}!g"
 #!substdef "!HOMER_LISTEN_PROTO!udp!g"
 #!substdef "!HOMER_LISTEN_IF!0.0.0.0!g"
-#!substdef "!HOMER_LISTEN_PORT!9060!g"
+#!substdef "!HOMER_LISTEN_PORT!{{ KAMAILIO_HEP_PORT }}!g"
 
 # #!substdef "!HOMER_STATS_SERVER!tcp:HOMER_LISTEN_IF:8888!g"
 


### PR DESCRIPTION
…t 9060 port

This commit will update kamailio.cfg, so it will use KAMAILIO_HEP_PORT from environment file instead of hard-coded 9060.