### PR TITLE
Docker file for cron container missing pl extension for crontab task.…

### DIFF
--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -7,7 +7,7 @@ RUN touch /var/log/cron.log
 RUN apt-get update -qq && apt-get install cron mysql-client -y && rm -rf /var/lib/apt/lists/*
 
 # Add our crontab file
-RUN echo "30 3 * * * /opt/homer_mysql_rotate >> /var/log/cron.log 2>&1" > /crons.conf
+RUN echo "30 3 * * * /opt/homer_mysql_rotate.pl >> /var/log/cron.log 2>&1" > /crons.conf
 RUN crontab /crons.conf
 
 COPY rotation.ini /opt/rotation.ini


### PR DESCRIPTION
… With this commit I changed /opt/homer_mysql_rotate to /opt/homer_mysql_rotate.pl

Currently crontab task is trying to run /opt/homer_mysql_rotate what is incorrect file name, it should be /opt/homer_mysql_rotate.pl. Changed file name in Docker file for cron container