### PR TITLE
Cleaning up apt packages.

### DIFF
--- a/kamailio/Dockerfile
+++ b/kamailio/Dockerfile
@@ -13,15 +13,25 @@ RUN apt-get update -qq
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xfb40d3e6508ea4c8
 RUN echo "deb http://deb.kamailio.org/kamailio jessie main" >> etc/apt/sources.list
 RUN echo "deb-src http://deb.kamailio.org/kamailio jessie main" >> etc/apt/sources.list
-RUN apt-get update -qq && apt-get install -f -yqq kamailio rsyslog kamailio-outbound-modules kamailio-geoip-modules kamailio-sctp-modules kamailio-tls-modules kamailio-websocket-modules kamailio-utils-modules kamailio-mysql-modules kamailio-extra-modules && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -qq && apt-get install -f -yqq \
+    kamailio \
+    rsyslog \
+    geoip-database \
+    geoip-database-extra \
+    kamailio-outbound-modules \
+    kamailio-geoip-modules \
+    kamailio-sctp-modules \
+    kamailio-tls-modules \
+    kamailio-websocket-modules \
+    kamailio-utils-modules \
+    kamailio-mysql-modules \
+    kamailio-extra-modules \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY kamailio.cfg /etc/kamailio/kamailio.cfg
 RUN chmod 775 /etc/kamailio/kamailio.cfg
 
 RUN ln -s /usr/lib64 /usr/lib/x86_64-linux-gnu/
-
-# GeoIP (http://dev.maxmind.com/geoip/legacy/geolite/)
-# RUN cd /usr/share/GeoIP && curl http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz > GeoLiteCity.dat.gz && gunzip GeoLiteCity.dat.gz
 
 COPY run.sh /run.sh
 


### PR DESCRIPTION
According to https://github.com/sipcapture/homer/wiki/Example:-GeoIP the commented out section is unnecessary in Debian.

I added a the geo-ip extras module which gives you the GeoIPCity.dat which is already referenced in the kamailio.cfg.